### PR TITLE
Fix Double rustup issue

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,7 @@ module.exports = {
       {
         message: `\
 [<%= nextRelease.version %>]\
-(https://github.com/fartts/superfluity/tree/<%= nextRelease.version%>)\
+(https://github.com/mysterycommand/parcel-plugin-wasm-pack/tree/<%= nextRelease.version%>)\
 - <%= new Date().toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'short',

--- a/src/WasmPackAsset.js
+++ b/src/WasmPackAsset.js
@@ -19,6 +19,8 @@ const { exec, proc } = require('./helpers');
 const RUST_TARGET = 'wasm32-unknown-unknown';
 const MAIN_FILES = ['src/lib.rs', 'src/main.rs'];
 
+let isRustInstalling = false;
+
 class WasmPackAsset extends Asset {
   get isWasm() {
     return (
@@ -58,7 +60,11 @@ class WasmPackAsset extends Asset {
      * the wasm32-unknown-unknown target
      * @see: https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/assets/RustAsset.js#L66
      */
-    await RustAsset.prototype.installRust.call(this);
+    if (!isRustInstalling) {
+      isRustInstalling = true;
+      await RustAsset.prototype.installRust.call(this);
+      isRustInstalling = false;
+    }
 
     /**
      * calling `getCargoConfig` creates:


### PR DESCRIPTION
See: [@fartts/fartts#478](https://github.com/fartts/fartts/pull/478) … it looks like 2 `installRust` processes get spawned and they clobber each other.