### PR TITLE
Export Names

### DIFF
--- a/src/WasmPackAsset.js
+++ b/src/WasmPackAsset.js
@@ -10,7 +10,7 @@ const TomlAsset = require('parcel-bundler/src/assets/TOMLAsset');
 const config = require('parcel-bundler/src/utils/config');
 
 const { cargoInstall, isInstalled } = require('./cargo-install');
-const { exec, proc } = require('./helpers');
+const { exec, proc, matches } = require('./helpers');
 
 /**
  * pulled out from Parcel's RustAsset class:
@@ -131,9 +131,13 @@ class WasmPackAsset extends Asset {
 
     const { dir, initPath, wasmPath } = this;
 
-    const init = (await fs.readFile(initPath))
-      .toString()
-      .replace('return wasm;', 'return __exports');
+    const initStr = (await fs.readFile(initPath)).toString();
+
+    const exportNames = Array.from(
+      matches(/export [const,function,class] (\w+)/g, initStr),
+    );
+    console.log(exportNames);
+    const init = initStr.replace('return wasm;', 'return __exports');
     await fs.writeFile(initPath, init);
 
     await this.addDependency(path.relative(dir, wasmPath));

--- a/src/WasmPackAsset.js
+++ b/src/WasmPackAsset.js
@@ -134,9 +134,18 @@ class WasmPackAsset extends Asset {
     const initStr = (await fs.readFile(initPath)).toString();
 
     const exportNames = Array.from(
-      matches(/export [const,function,class] (\w+)/g, initStr),
+      matches(/export\ (?:class|const|function)\ (\w+)/g, initStr).map(
+        ([_, name]) => name,
+      ),
     );
-    console.log(exportNames);
+    `
+
+${JSON.stringify(exportNames, null, 2)}
+
+`
+      .split('\n')
+      .forEach(line => logger.log(line));
+
     const init = initStr.replace('return wasm;', 'return __exports');
     await fs.writeFile(initPath, init);
 
@@ -255,7 +264,10 @@ module.exports = init(require('${path.relative(dir, wasmPath)}'));
       },
     );
 
-    logger.verbose(JSON.stringify({ stdout }));
+    JSON.stringify(JSON.parse(stdout), null, 2)
+      .split('\n')
+      .forEach(line => logger.log(line));
+
     const { target_directory: targetDir } = JSON.parse(stdout);
     return path.join(
       targetDir,

--- a/src/WasmPackPackager.js
+++ b/src/WasmPackPackager.js
@@ -5,14 +5,14 @@ const JSPackager = require('parcel-bundler/src/packagers/JSPackager');
 const { rel } = require('./helpers');
 
 const moduleTpl = (wasmName, wasmId, entryName) => `\
-require('${wasmName}')
+require("${wasmName}")
   .then(wasm => {
     // replace the entry in the cache with the loaded wasm module
-    module.bundle.cache['${wasmId}'] = null;
-    module.bundle.register('${wasmId}', wasm);
+    module.bundle.cache["${wasmId}"] = null;
+    module.bundle.register("${wasmId}", wasm);
   })
   .then(() => {
-    require('${entryName}');
+    require("${entryName}");
   });
 `;
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,4 +64,11 @@ function rel(from, to) {
   return relativePath.replace('\\', '/');
 }
 
-module.exports = { exec, proc, rel };
+function* matches(regex, str) {
+  let match;
+  while ((match = regex.exec(str)) !== null) {
+    yield match;
+  }
+}
+
+module.exports = { exec, proc, rel, matches };


### PR DESCRIPTION
Returning `__exports` from the promise was never the right thing to do, but neither (I think) is returning the `wasm` object itself. This change builds a list of `export`ed names (class, const, or function … I think that's all that makes sense to export? … all that `wasm-pack` will export anyway) and returns an object of those names/values … which I think is the correct public interface.

This is a BREAKING CHANGE in that the old `__exports` object exposed a bunch of "bindgen internals" (stuff like `__widl_f_set_height_HTMLCanvasElement` and others). If you were relying on that, you can't now. Sorry?