### PR TITLE
Remove Yarn/npm from engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "engines": {
     "node": "10.15.3",
     "npm": "6.9.0",
-    "yarn": "1.15.2"
+    "yarn": "1.16.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": "10.15.3",
-    "npm": "6.9.0",
-    "yarn": "1.16.0"
+    "node": "10.15.3"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test": "jest"
   },
   "engines": {
-    "node": "10.15.3"
+    "node": "10.15.3",
+    "npm": "6.9.0",
+    "yarn": "1.16.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Having these in engines puts undo burden on any consumer (so far just me, but even so).